### PR TITLE
Fix: Update logic in translateError to allow for non-Error params (fixes #25)

### DIFF
--- a/lib/LangModule.js
+++ b/lib/LangModule.js
@@ -183,7 +183,7 @@ class LangModule extends AbstractModule {
    * @returns The translated error (if passed error is not an instance of AdaptError, the original value will be returned)
    */
   translateError (lang, error) {
-    return error.constructor.name.endsWith('Error') ? this.translate(lang, `error.${error.code}`, error.data ?? error) : error
+    return error?.constructor.name.endsWith('Error') ? this.translate(lang, `error.${error.code}`, error.data ?? error) : error
   }
 }
 


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
#25 

[//]: # (Delete as appropriate)
### Fix
* Error thrown when LangModule#translateError passed non-Error value