### PR TITLE
Fix: Standard linting errors in check.js (fixes #33)

### DIFF
--- a/bin/check.js
+++ b/bin/check.js
@@ -8,7 +8,7 @@ import path from 'path'
 
 const root = `${process.cwd().replaceAll(path.sep, '/')}/node_modules`
 
-const underline  = (s='', topLine=true) => {
+const underline = (s = '', topLine = true) => {
   const line = () => ''.padEnd(80, '-')
   console.log(`${topLine ? line() + '\n' : ''}  ${s}\n${line()}`)
 }


### PR DESCRIPTION
Fixes #33

### Fix
* Add spaces around default parameter values in the `underline` function to comply with standard code style conventions